### PR TITLE
500エラーを返却する問題の修正

### DIFF
--- a/frontend/src/__tests__/header.spec.tsx
+++ b/frontend/src/__tests__/header.spec.tsx
@@ -15,34 +15,45 @@ describe("Header component", () => {
   afterEach(() => {
     vi.resetAllMocks();
   });
+
   describe.each(cases)("%s", (story) => {
     const Story = composeStory(stories[story], stories.default);
+
     it("render component", () => {
       const { container } = render(<Story />);
+
       expect(container.firstChild).toMatchSnapshot();
     });
+
     if (story === "Default") {
       it("hidden state components", () => {
         const { queryByText, queryByRole } = render(<Story />);
+
         expect(queryByRole("button", { name: "Login" })).toBeNull();
         expect(queryByText("logged in user")).toBeNull();
       });
     }
+
     if (story === "LoggedIn") {
       it("displayed user name", () => {
         const { queryByText } = render(<Story />);
         expect(queryByText("logged in user")).not.toBeNull();
       });
     }
+
     if (story === "ShouldLogin") {
       it("displayed login button", () => {
         const { queryByRole, queryByText } = render(<Story />);
+
         expect(queryByText("logged in user")).toBeNull();
         expect(queryByRole("button", { name: "Login" })).not.toBeNull();
       });
+
       it("call toggle auth modal request", () => {
         const request = vi.fn();
+
         const { getByRole } = render(<Story requestLoginModal={request} />);
+
         expect(request).not.toHaveBeenCalled();
         user.click(getByRole("button", { name: "Login" }));
         expect(request).toHaveBeenCalled();

--- a/frontend/src/components/authModal.tsx
+++ b/frontend/src/components/authModal.tsx
@@ -1,22 +1,22 @@
 import { FC } from "react";
 import { useRecoilValue } from "recoil";
 import {
-  authState,
+  isDisplayedAuthModal,
   useListenAuth,
-  useOpenAuthModalRequest,
+  useSwitchDisplayAuthModal,
 } from "~/stores/auth";
 import SignInTemplate from "~/templates/signin";
 import Modal from "./modal";
 
 const AuthModal: FC = () => {
-  const state = useRecoilValue(authState);
-  const modalRequest = useOpenAuthModalRequest();
+  const isDisplayed = useRecoilValue(isDisplayedAuthModal);
+  const switchDisplayModal = useSwitchDisplayAuthModal();
   useListenAuth();
   return (
     <>
       <Modal
-        visible={!!(state.openAuthModalRequest && !state.subscription?.uid)}
-        onClickBackground={() => modalRequest(false)}
+        visible={isDisplayed}
+        onClickBackground={() => switchDisplayModal(false)}
         width={450}
         height={420}
       >

--- a/frontend/src/components/authModal.tsx
+++ b/frontend/src/components/authModal.tsx
@@ -3,20 +3,20 @@ import { useRecoilValue } from "recoil";
 import {
   authState,
   useListenAuth,
-  useToggleAuthModalRequest,
+  useOpenAuthModalRequest,
 } from "~/stores/auth";
 import SignInTemplate from "~/templates/signin";
 import Modal from "./modal";
 
 const AuthModal: FC = () => {
   const state = useRecoilValue(authState);
-  const toggle = useToggleAuthModalRequest();
+  const modalRequest = useOpenAuthModalRequest();
   useListenAuth();
   return (
     <>
       <Modal
         visible={!!(state.openAuthModalRequest && !state.subscription?.uid)}
-        onClickBackground={() => toggle()}
+        onClickBackground={() => modalRequest(false)}
         width={450}
         height={420}
       >

--- a/frontend/src/components/header.tsx
+++ b/frontend/src/components/header.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import {
   isSubscribedState,
   uidState,
-  useOpenAuthModalRequest,
+  useSwitchDisplayAuthModal,
 } from "~/stores/auth";
 import { useRecoilValue } from "recoil";
 import { profileState } from "~/stores/profile";
@@ -74,7 +74,7 @@ export const HeaderTemplate: FC<TemplateProps> = (
 );
 
 const Header: FC = () => {
-  const openAuthModalRequest = useOpenAuthModalRequest();
+  const switchDisplayModal = useSwitchDisplayAuthModal();
   const { currentUser } = useRecoilValue(profileState);
   const uid = useRecoilValue(uidState);
   const isSubscribed = useRecoilValue(isSubscribedState);
@@ -83,7 +83,7 @@ const Header: FC = () => {
       isSubscribed={isSubscribed}
       uid={uid}
       currentUser={currentUser}
-      requestLoginModal={() => openAuthModalRequest(true)}
+      requestLoginModal={() => switchDisplayModal(true)}
     />
   );
 };

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -8,12 +8,12 @@ interface Subscription {
 
 type Atom = {
   subscription?: Subscription;
-  openAuthModalRequest: boolean;
+  requestsToDisplayAuthModal: boolean;
 };
 
 export const authState = atom<Atom>({
   key: "auth",
-  default: { subscription: undefined, openAuthModalRequest: false },
+  default: { subscription: undefined, requestsToDisplayAuthModal: false },
 });
 
 export const uidState = selector<string | undefined>({
@@ -26,12 +26,19 @@ export const isSubscribedState = selector<boolean>({
   get: ({ get }) => get(authState)?.subscription !== undefined,
 });
 
-export const useOpenAuthModalRequest = () => {
+export const isDisplayedAuthModal = selector<boolean>({
+  key: "auth/isDisplayedAuthModal",
+  get: ({ get }) =>
+    get(authState).requestsToDisplayAuthModal && get(isSubscribedState) &&
+    !get(uidState),
+});
+
+export const useSwitchDisplayAuthModal = () => {
   const request = useSetRecoilState(authState);
-  return (state: boolean) =>
+  return (open: boolean) =>
     request((atom) => ({
       ...atom,
-      openAuthModalRequest: state,
+      requestsToDisplayAuthModal: open,
     }));
 };
 
@@ -44,7 +51,9 @@ export const useListenAuth = () => {
     let unsubscribe = onAuthStateChanged(auth, (user) => {
       setAuth((atom) => ({
         ...atom,
-        openAuthModalRequest: user?.uid ? false : atom.openAuthModalRequest,
+        requestsToDisplayAuthModal: user?.uid
+          ? false
+          : atom.requestsToDisplayAuthModal,
         subscription: { uid: user?.uid ?? undefined },
       }));
     });

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
 
   "scripts": {
+    "dev": "yarn workspace @rasp/frontend dev",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
名前を変更した関数名を利用していたコンポーネントで変更を反映し忘れていたため、モジュールを見つけることができなくなっていた

## 変更内容
- 関数の名前変更
- インデントの修正